### PR TITLE
Taylor error

### DIFF
--- a/models/Double-Pendulum/Double-Pendulum.jl
+++ b/models/Double-Pendulum/Double-Pendulum.jl
@@ -74,7 +74,7 @@ vars_idx = Dict(:state_vars=>1:4, :control_vars=>5:6);
 ivp = @ivp(x' = double_pendulum!(x), dim: 6, x(0) ∈ X₀ × U₀);
 
 period = use_less_robust_controller ? 0.05 : 0.02;  # control period
-T = 20 * period;  # time horizon
+T = 3 * period;  # time horizon
 
 prob = ControlledPlant(ivp, controller, vars_idx, period);
 
@@ -85,7 +85,7 @@ safe_states = use_less_robust_controller ?
 # ## Results
 
 alg = TMJets20(abstol=1e-8, orderT=4, orderQ=2);
-alg_nn = Ai2();
+alg_nn = SampledApprox(nsamples=100, include_vertices=false);
 
 @time sol = solve(prob, T=T, alg_nn=alg_nn, alg=alg);
 


### PR DESCRIPTION
Settings to reproduce the error below. Do not merge. See #165. 

```julia
julia> include("Double-Pendulum/Double-Pendulum.jl")
ERROR: LoadError: UndefRefError: access to undefined reference
Stacktrace:
  [1] getindex
    @ ./array.jl:801 [inlined]
  [2] _broadcast_getindex
    @ ./broadcast.jl:614 [inlined]
  [3] _getindex
    @ ./broadcast.jl:644 [inlined]
  [4] _broadcast_getindex
    @ ./broadcast.jl:620 [inlined]
  [5] _getindex
    @ ./broadcast.jl:644 [inlined]
  [6] _broadcast_getindex
    @ ./broadcast.jl:620 [inlined]
  [7] getindex
    @ ./broadcast.jl:575 [inlined]
  [8] macro expansion
    @ ./broadcast.jl:984 [inlined]
  [9] macro expansion
    @ ./simdloop.jl:77 [inlined]
 [10] copyto!
    @ ./broadcast.jl:983 [inlined]
 [11] copyto!
    @ ./broadcast.jl:936 [inlined]
 [12] copy
    @ ./broadcast.jl:908 [inlined]
 [13] materialize
    @ ./broadcast.jl:883 [inlined]
 [14] picard_iteration(f!::typeof(double_pendulum!), dx::Vector{TaylorModels.TaylorModel1{TaylorN{Float64}, Float64}}, xTM1K::Vector{TaylorModels.TaylorModel1{TaylorN{Float64}, Float64}}, params::Nothing, t::Taylor1{Float64}, x0::Vector{TaylorModels.TaylorModelN{6, Float64, Float64}}, box::IntervalBox{6, Float64}, #unused#::Val{true})
    @ TaylorModels ~/.julia/packages/TaylorModels/JisN7/src/validatedODEs.jl:643
 [15] _validate_step!(xTM1K::Vector{TaylorModels.TaylorModel1{TaylorN{Float64}, Float64}}, f!::Function, dx::Vector{TaylorModels.TaylorModel1{TaylorN{Float64}, Float64}}, x0::Vector{TaylorModels.TaylorModelN{6, Float64, Float64}}, params::Nothing, x::Vector{Taylor1{TaylorN{Float64}}}, t::Taylor1{Float64}, box::IntervalBox{6, Float64}, dof::Int64, rem::Vector{IntervalArithmetic.Interval{Float64}}, abstol::Float64, δt::Float64, sign_tstep::Int64, E::Vector{IntervalArithmetic.Interval{Float64}}, E′::Vector{IntervalArithmetic.Interval{Float64}}, polv::Vector{Taylor1{TaylorN{Float64}}}, low_ratiov::Vector{Float64}, hi_ratiov::Vector{Float64}, adaptive::Bool, minabstol::Float64; ε::Float64, δ::Float64, validatesteps::Int64, extrasteps::Int64)
    @ TaylorModels ~/.julia/packages/TaylorModels/JisN7/src/validatedODEs.jl:696
 [16] validated_integ2(f!::typeof(double_pendulum!), X0::IntervalBox{6, Float64}, t0::Float64, tf::Float64, orderQ::Int64, orderT::Int64, abstol::Float64, params::Nothing; parse_eqs::Bool, maxsteps::Int64, absorb::Bool, adaptive::Bool, minabstol::Float64, validatesteps::Int64, ε::Float64, δ::Float64, absorb_steps::Int64)
    @ TaylorModels ~/.julia/packages/TaylorModels/JisN7/src/validatedODEs.jl:826
 [17] _solve_external(f!::Function, X0::CartesianProduct{Float64, BallInf{Float64, Vector{Float64}}, Zonotope{Float64, Vector{Float64}, Matrix{Float64}}}, t0::Float64, T::Float64, orderQ::Int64, orderT::Int64, abstol::Float64, maxsteps::Int64, Δt0::IntervalArithmetic.Interval{Float64}; kwargs::Base.Iterators.Pairs{Symbol, Any, Tuple{Symbol, Symbol}, NamedTuple{(:parse_eqs, :solver_name), Tuple{Bool, typeof(TaylorModels.validated_integ2)}}})
    @ ReachabilityAnalysis ~/.julia/dev/ReachabilityAnalysis/src/Algorithms/TMJets/common.jl:60
 [18] post(alg::TMJets20{Float64, ZonotopeEnclosure}, ivp::InitialValueProblem{BlackBoxContinuousSystem{typeof(double_pendulum!)}, CartesianProduct{Float64, BallInf{Float64, Vector{Float64}}, Zonotope{Float64, Vector{Float64}, Matrix{Float64}}}}, timespan::IntervalArithmetic.Interval{Float64}; Δt0::IntervalArithmetic.Interval{Float64}, external::Bool, kwargs::Base.Iterators.Pairs{Symbol, typeof(TaylorModels.validated_integ2), Tuple{Symbol}, NamedTuple{(:solver_name,), Tuple{typeof(TaylorModels.validated_integ2)}}})
    @ ReachabilityAnalysis ~/.julia/dev/ReachabilityAnalysis/src/Algorithms/TMJets/TMJets20/post.jl:32
 [19] _solve(cp::ControlledPlant{BlackBoxContinuousSystem{typeof(double_pendulum!)}, CartesianProduct{Float64, BallInf{Float64, Vector{Float64}}, ZeroSet{Float64}}, UnitRange{Int64}, Float64, NeuralNetworkAnalysis.NoNormalization, NeuralNetworkAnalysis.NoPreprocessing}, cpost::TMJets20{Float64, ZonotopeEnclosure}, solver::SampledApprox, time_span::IntervalArithmetic.Interval{Float64}, sampling_time::Float64, apply_initial_control::Bool)
    @ NeuralNetworkAnalysis ~/.julia/dev/NeuralNetworkAnalysis/src/solve.jl:144
 [20] solve(::ControlledPlant{BlackBoxContinuousSystem{typeof(double_pendulum!)}, CartesianProduct{Float64, BallInf{Float64, Vector{Float64}}, ZeroSet{Float64}}, UnitRange{Int64}, Float64, NeuralNetworkAnalysis.NoNormalization, NeuralNetworkAnalysis.NoPreprocessing}; kwargs::Base.Iterators.Pairs{Symbol, Any, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:T, :alg_nn, :alg), Tuple{Float64, SampledApprox, TMJets20{Float64, ZonotopeEnclosure}}}})
    @ NeuralNetworkAnalysis ~/.julia/dev/NeuralNetworkAnalysis/src/solve.jl:61
 [21] top-level scope
    @ ./timing.jl:210
 [22] include(fname::String)
    @ Base.MainInclude ./client.jl:444
 [23] top-level scope
    @ REPL[8]:1
in expression starting at /home/christian/.julia/dev/NeuralNetworkAnalysis/models/Double-Pendulum/Double-Pendulum.jl:90
```