### PR TITLE
Fix deprecation warning in `RecursiveArrayTools`

### DIFF
--- a/src/init_OrdinaryDiffEq.jl
+++ b/src/init_OrdinaryDiffEq.jl
@@ -39,7 +39,7 @@ function EnsembleSimulationSolution(simulations, controls, disturbances)
     @assert n == length(controls) == length(disturbances) "incompatible lengths"
     @assert all(m == length(piece) for piece in simulations)
 
-    simulations_new = @inbounds [[simulations[i][j] for i in 1:n] for j in 1:m]
+    simulations_new = @inbounds [[simulations[i].u[j] for i in 1:n] for j in 1:m]
     controls_new = @inbounds [[controls[i][j] for i in 1:n] for j in 1:m]
     disturbances_new = @inbounds [[(isassigned(disturbances, i) ? disturbances[i][j] : nothing)
                                    for i in 1:n] for j in 1:m]

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -80,12 +80,11 @@ function simulate(cp::AbstractControlProblem, args...; kwargs...)
         T = i < iterations ? (t + τ) : tend(time_span)
 
         # simulate system for the next period
-        simulations[i] = _solve_ensemble(ivp, extended, (t, T);
-                                         inplace=inplace)
+        simulations[i] = _solve_ensemble(ivp, extended, (t, T); inplace=inplace)
 
         # project to state variables
         for j in 1:trajectories
-            ode_solution = simulations[i][j]
+            ode_solution = simulations[i].u[j]
             final_extended = ode_solution.u[end]
             x0_vec[j] = final_extended[st_vars]
         end


### PR DESCRIPTION
```julia
`Base.getindex(VA::AbstractVectorOfArray{T, N, A}, I::Int) where {T, N, A <: Union{AbstractArray, AbstractVectorOfArray}}`
    is deprecated, use `VA.u[I]` instead.
```